### PR TITLE
Renaming "Groceries" to "Grocery store tour". Resolves #18.

### DIFF
--- a/frontend/add-client/services.component.tsx
+++ b/frontend/add-client/services.component.tsx
@@ -55,8 +55,8 @@ export default function Services(props: StepComponentProps) {
                 <span>Nutrition</span>
               </label>
               <label>
-                <input type="checkbox" name="services" value="groceries" checked={services.groceries} onChange={handleChange} />
-                <span>Groceries</span>
+                <input type="checkbox" name="services" value="groceryTour" checked={services.groceryTour} onChange={handleChange} />
+                <span>Grocery store tour</span>
               </label>
               <label>
                 <input type="checkbox" name="services" value="cookingClass" checked={services.cookingClass} onChange={handleChange} />
@@ -120,7 +120,7 @@ const defaultServices = {
   foodStamps: false,
   chronicDiseaseTesting: false,
   nutrition: false,
-  groceries: false,
+  groceryTour: false,
   cookingClass: false,
   PrEPClinic: false,
   legalHelp: false,

--- a/frontend/util/city-input.component.tsx
+++ b/frontend/util/city-input.component.tsx
@@ -39,7 +39,7 @@ export default function CityInput(props) {
             <button type="button" className="unstyled" onClick={() => {
               props.setCity(possibleCity.city)
               inputRef.current.blur()
-            }}>
+            }} tabIndex={-1}>
               {possibleCity.city}
             </button>
           </li>


### PR DESCRIPTION
See #18 