### PR TITLE
possible solutuion for autocomplete chrome issue

### DIFF
--- a/frontend/add-client/form-inputs/basic-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/basic-information-inputs.component.tsx
@@ -27,7 +27,8 @@ export default function BasicInformationInputs(
             value={firstName}
             onChange={evt => setFirstName(evt.target.value)}
             required
-            autoComplete="off"
+            autoComplete="new-password"
+            autoCapitalize="words"
             autoFocus
           />
         </label>
@@ -39,7 +40,8 @@ export default function BasicInformationInputs(
             type="text"
             value={lastName}
             onChange={evt => setLastName(evt.target.value)}
-            autoComplete="off"
+            autoComplete="new-password"
+            autoCapitalize="words"
             required
           />
         </label>
@@ -61,7 +63,7 @@ export default function BasicInformationInputs(
           <select
             value={gender}
             onChange={evt => setGender(evt.target.value)}
-            autoComplete="off"
+            autoComplete="new-password"
             required
           >
             <option value="female">Female</option>

--- a/frontend/add-client/form-inputs/basic-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/basic-information-inputs.component.tsx
@@ -28,7 +28,6 @@ export default function BasicInformationInputs(
             onChange={evt => setFirstName(evt.target.value)}
             required
             autoComplete="new-password"
-            autoCapitalize="words"
             autoFocus
           />
         </label>
@@ -41,7 +40,6 @@ export default function BasicInformationInputs(
             value={lastName}
             onChange={evt => setLastName(evt.target.value)}
             autoComplete="new-password"
-            autoCapitalize="words"
             required
           />
         </label>

--- a/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
@@ -76,7 +76,7 @@ export default React.forwardRef(function ContactInformationInputs(
             value={email}
             onChange={evt => setEmail(evt.target.value)}
             required
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </label>
       </div>
@@ -89,7 +89,7 @@ export default React.forwardRef(function ContactInformationInputs(
             onChange={evt => setStreetAddress(evt.target.value)}
             required
             placeholder="1211 W. 3200 S."
-            autoComplete="off"
+            autoComplete="new-password"
           />
         </label>
       </div>

--- a/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
@@ -35,7 +35,7 @@ export default React.forwardRef(function ContactInformationInputs(
   });
 
   return (
-    <form onSubmit={props.handleSubmit} autoComplete="off">
+    <form onSubmit={props.handleSubmit} autoComplete="new-password">
       {props.showDateOfIntake && (
         <div>
           <label>
@@ -75,8 +75,8 @@ export default React.forwardRef(function ContactInformationInputs(
             type="email"
             value={email}
             onChange={evt => setEmail(evt.target.value)}
-            required
             autoComplete="new-password"
+            required
           />
         </label>
       </div>
@@ -118,6 +118,7 @@ export default React.forwardRef(function ContactInformationInputs(
             type="text"
             value={zip}
             onChange={evt => setZip(evt.target.value)}
+            autoComplete="new-password"
             required
           />
         </label>

--- a/frontend/add-client/form-inputs/demographic-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/demographic-information-inputs.component.tsx
@@ -77,7 +77,7 @@ export default function DemographicInformationInputs(
   };
 
   return (
-    <form onSubmit={handleSubmit} autoComplete="off">
+    <form onSubmit={handleSubmit} autoComplete="new-password">
       <div>
         <label>
           <span>Civil status</span>

--- a/frontend/add-client/list-duplicates.component.tsx
+++ b/frontend/add-client/list-duplicates.component.tsx
@@ -32,7 +32,7 @@ export default function ListDuplicates(props: ListDuplicatesProps) {
         </div>
       </div>
       <div>
-        <form onSubmit={handleSubmit} autoComplete="off">
+        <form onSubmit={handleSubmit} autoComplete="new-password">
           <table>
             <thead>
               <tr>

--- a/frontend/util/city-input.component.tsx
+++ b/frontend/util/city-input.component.tsx
@@ -48,7 +48,6 @@ export default function CityInput(props) {
         required
         ref={inputRef}
         autoComplete="new-password"
-        autoCapitalize="words"
         onFocus={() => setSelectedIndex(0)}
         onKeyDown={onKeyDown}
       />

--- a/frontend/util/city-input.component.tsx
+++ b/frontend/util/city-input.component.tsx
@@ -48,6 +48,7 @@ export default function CityInput(props) {
         required
         ref={inputRef}
         autoComplete="new-password"
+        autoCapitalize="words"
         onFocus={() => setSelectedIndex(0)}
         onKeyDown={onKeyDown}
       />

--- a/frontend/util/city-input.component.tsx
+++ b/frontend/util/city-input.component.tsx
@@ -47,7 +47,7 @@ export default function CityInput(props) {
         onChange={evt => props.setCity(evt.target.value)}
         required
         ref={inputRef}
-        autoComplete="off"
+        autoComplete="new-password"
         onFocus={() => setSelectedIndex(0)}
         onKeyDown={onKeyDown}
       />

--- a/frontend/util/phone-input.component.tsx
+++ b/frontend/util/phone-input.component.tsx
@@ -12,7 +12,7 @@ export default function PhoneInput(props: PhoneInputProps) {
       pattern="\(?[0-9]{3}\)?[ ]?-?[0-9]{3}-?[0-9]{4}"
       required
       autoFocus={props.autoFocus}
-      autoComplete="off"
+      autoComplete="new-password"
     />
   );
 


### PR DESCRIPTION
Changing input fields that we do not want to autocomplete to autoComplete="new-password" did successfully stop the autocomplete and suggest in Chrome without breaking the same in Firefox. 

Ruled out the false, readonly removed on focus, and false input field methods.