### PR TITLE
possible date Client Date of Intake fix

### DIFF
--- a/frontend/add-client/add-client.component.tsx
+++ b/frontend/add-client/add-client.component.tsx
@@ -21,8 +21,7 @@ import { WeeklyEmployedHours } from "./form-inputs/demographic-information-input
 export default function AddClient(props: AddClientProps) {
   const scope = useCss(css);
 
-  const [step, setStep] = useState<Step>(Step.CONTACT_INFORMATION);
-  // const [step, setStep] = useState<Step>(Step.CHECK_DUPLICATE);
+  const [step, setStep] = useState<Step>(Step.CHECK_DUPLICATE);
   const [clientState, setClientState] = useState<ClientState>({});
   const [duplicateWarning, setDuplicateWarning] = useState<DuplicateWarning>(
     null

--- a/frontend/add-client/add-client.component.tsx
+++ b/frontend/add-client/add-client.component.tsx
@@ -21,7 +21,8 @@ import { WeeklyEmployedHours } from "./form-inputs/demographic-information-input
 export default function AddClient(props: AddClientProps) {
   const scope = useCss(css);
 
-  const [step, setStep] = useState<Step>(Step.CHECK_DUPLICATE);
+  const [step, setStep] = useState<Step>(Step.CONTACT_INFORMATION);
+  // const [step, setStep] = useState<Step>(Step.CHECK_DUPLICATE);
   const [clientState, setClientState] = useState<ClientState>({});
   const [duplicateWarning, setDuplicateWarning] = useState<DuplicateWarning>(
     null

--- a/frontend/add-client/add-client.component.tsx
+++ b/frontend/add-client/add-client.component.tsx
@@ -225,6 +225,7 @@ ${mediaMobile} {
 
   & .form-with-hints form {
     width: 30rem;
+    justify-contents: center;
   }
 
   & .form-with-hints form > div > label > span {

--- a/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
@@ -160,10 +160,12 @@ export default React.forwardRef(function ContactInformationInputs(
 });
 
 function getTodayAsString() {
-  const date = new Date().toISOString();
-  return date.slice(0, date.indexOf("T"));
+  const day = new Date().getDate();
+  const year = new Date().getFullYear();
+  const month = new Date().getMonth();
 
-  console.log(date);
+  const date = `${year}-${month > 10 ? "" : "0"}${month + 1}-${day}`;
+  return date;
 }
 
 type ContactInformationInputsProps = {

--- a/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/contact-information-inputs.component.tsx
@@ -162,6 +162,8 @@ export default React.forwardRef(function ContactInformationInputs(
 function getTodayAsString() {
   const date = new Date().toISOString();
   return date.slice(0, date.indexOf("T"));
+
+  console.log(date);
 }
 
 type ContactInformationInputsProps = {


### PR DESCRIPTION
.toISOString was setting it to tomorrows date

Tried .toLocaleDateString first, but the input field defaulted to "mm/dd/yyyy" placeholder, so went with work around. Grabbing the day, year, and month separate and converting to the same format .toISOString was using. 

Also added a quick fix to a centering issue that was showing up in the add client hint/instructions header