### PR TITLE
Beginnings of client interactions page, including global add. See #184.

### DIFF
--- a/frontend/home/home.component.tsx
+++ b/frontend/home/home.component.tsx
@@ -32,8 +32,8 @@ export default function Home(props: HomeProps) {
         />
         <HomeCard
           iconUrl={recordVisitUrl}
-          title="Add a client visit"
-          link="add-client-visit"
+          title="Add a client interaction"
+          link="add-client-interaction"
         />
         <HomeCard
           iconUrl={reportIssueUrl}

--- a/frontend/navbar/sidebar.component.tsx
+++ b/frontend/navbar/sidebar.component.tsx
@@ -57,7 +57,17 @@ export default function Sidebar(props: SidebarProps) {
               onClick={maybeHideSidebar}
               getProps={maybeActiveLink}
             >
-              <div>Add a client</div>
+              <div>Add client</div>
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="add-client-interaction"
+              className="nav-link"
+              onClick={maybeHideSidebar}
+              getProps={maybeActiveLink}
+            >
+              <div>Add client interaction</div>
             </Link>
           </li>
           <li>
@@ -67,17 +77,7 @@ export default function Sidebar(props: SidebarProps) {
               onClick={maybeHideSidebar}
               getProps={maybeActiveLink}
             >
-              <div>Add a case note</div>
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="record-client-visit"
-              className="nav-link"
-              onClick={maybeHideSidebar}
-              getProps={maybeActiveLink}
-            >
-              <div>Add a client visit</div>
+              <div>Add case note</div>
             </Link>
           </li>
           <li>

--- a/frontend/report-issue/report-issue.component.tsx
+++ b/frontend/report-issue/report-issue.component.tsx
@@ -6,7 +6,8 @@ import easyFetch from "../util/easy-fetch";
 
 export default function ReportIssue({
   title = "Report an issue",
-  missingFeature
+  missingFeature,
+  hideHeader
 }: ReportIssueProps) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -38,7 +39,7 @@ export default function ReportIssue({
 
   return (
     <>
-      <PageHeader title={title} />
+      {!hideHeader && <PageHeader title={title} />}
       {showForm()}
     </>
   );
@@ -162,4 +163,5 @@ type ReportIssueProps = {
   path?: string;
   title?: string;
   missingFeature?: boolean;
+  hideHeader?: boolean;
 };

--- a/frontend/root.component.tsx
+++ b/frontend/root.component.tsx
@@ -11,6 +11,7 @@ import ViewClient from "./view-edit-client/view-client.component";
 import ClientList from "./client-list/client-list.component";
 import Growls from "./growls/growls.component";
 import AddCaseNote from "./view-edit-client/case-notes/add-case-note.component";
+import AddClientInteraction from "./view-edit-client/interactions/add-client-interaction.component";
 
 export default function Root() {
   return (
@@ -21,12 +22,8 @@ export default function Root() {
             <Home path="/" />
             <AddClient path="add-client" />
             <ClientList path="client-list" />
+            <AddClientInteraction isGlobalAdd path="add-client-interaction" />
             <ViewClient path="clients/:clientId/*" />
-            <ReportIssue
-              missingFeature
-              title="Record Client Visit"
-              path="record-client-visit"
-            />
             <AddCaseNote isGlobalAdd path="add-case-note" />
             <ReportIssue path="report-issue" />
             <ReportIssueSuccess path="report-issue/:issueId" />

--- a/frontend/view-edit-client/interactions/add-client-interaction.component.tsx
+++ b/frontend/view-edit-client/interactions/add-client-interaction.component.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import PageHeader from "../../page-header.component";
+import ReportIssue from "../../report-issue/report-issue.component";
+import SingleClientSearchInputComponent from "../../client-search/single-client/single-client-search-input.component";
+import easyFetch from "../../util/easy-fetch";
+
+export default function AddClientInteraction(props: AddClientInteractionProps) {
+  if (!localStorage.getItem("client-interactions")) {
+    return (
+      <ReportIssue
+        missingFeature
+        hideHeader={!props.isGlobalAdd}
+        title="Add client interaction"
+      />
+    );
+  }
+
+  const serviceSelectRef = React.useRef(null);
+  const [services, setServices] = React.useState([]);
+
+  React.useEffect(() => {
+    const abortController = new AbortController();
+
+    easyFetch("/api/services", { signal: abortController.signal })
+      .then(data => setServices(data.services))
+      .catch(err => {
+        setTimeout(() => {
+          throw err;
+        });
+      });
+
+    return () => abortController.abort();
+  }, []);
+
+  return (
+    <>
+      {props.isGlobalAdd && <PageHeader title="Add a client interaction" />}
+      <form className="card" onSubmit={handleSubmit}>
+        <SingleClientSearchInputComponent
+          autoFocus
+          nextThingToFocusRef={serviceSelectRef}
+        />
+        <select ref={serviceSelectRef}>
+          {services.map(service => (
+            <option key={service.id}>{service.serviceName}</option>
+          ))}
+        </select>
+      </form>
+    </>
+  );
+
+  function handleSubmit(evt) {
+    evt.preventDefault();
+    alert("handleSubmit not yet implemented");
+  }
+}
+
+type AddClientInteractionProps = {
+  path: string;
+  isGlobalAdd?: boolean;
+};

--- a/frontend/view-edit-client/view-client.component.tsx
+++ b/frontend/view-edit-client/view-client.component.tsx
@@ -13,6 +13,7 @@ import ClientHome from "./client-home/client-home.component";
 import ClientHistory from "./client-history/client-history.component";
 import ClientAddNewInfo from "./add-new/client-add-new-info.component";
 import AddCaseNote from "./case-notes/add-case-note.component";
+import AddClientInteraction from "./interactions/add-client-interaction.component";
 
 export default function ViewClient(props: ViewClientProps) {
   const [client, setClient] = React.useState<SingleClient>(null);
@@ -87,6 +88,7 @@ export default function ViewClient(props: ViewClientProps) {
         <ClientHistory path="history" {...childProps} />
         <ClientAddNewInfo path="add-info" {...childProps} />
         <AddCaseNote path="add-case-note" {...childProps} />
+        <AddClientInteraction path="add-client-interaction" {...childProps} />
       </Router>
     </>
   );


### PR DESCRIPTION
**In order to see this UI before Phase 2 is finished, you must run `localStorage.setItem('client-interactions', true)`**

![client-interactions-1](https://user-images.githubusercontent.com/5524384/61986296-8076c500-afcb-11e9-96f6-a409a7984ab4.gif)
