### PR TITLE
Grouping services by program in Add/Edit client

### DIFF
--- a/frontend/add-client/form-inputs/intake-services-inputs.component.tsx
+++ b/frontend/add-client/form-inputs/intake-services-inputs.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { groupBy } from "lodash-es";
 
 export default React.forwardRef<ServicesRef, IntakeServicesInputsProps>(
   function IntakeServicesInputs(props, ref) {
@@ -13,23 +14,30 @@ export default React.forwardRef<ServicesRef, IntakeServicesInputsProps>(
       };
     });
 
+    const groupedServices = groupBy<Service>(props.services, "programName");
+
     return (
       <div>
         <div className="vertical-options">
-          {props.services.map(service => (
-            <label key={service.id}>
-              <input
-                type="checkbox"
-                name="services"
-                value={service.id}
-                checked={checkedServices.some(
-                  checkedService => checkedService === service.id
-                )}
-                onChange={handleChange}
-                autoFocus
-              />
-              <span>{service.serviceName}</span>
-            </label>
+          {Object.entries(groupedServices).map(([programName, services]) => (
+            <div key={programName}>
+              <h4>{programName}</h4>
+              {services.map(service => (
+                <label key={service.id}>
+                  <input
+                    type="checkbox"
+                    name="services"
+                    value={service.id}
+                    checked={checkedServices.some(
+                      checkedService => checkedService === service.id
+                    )}
+                    onChange={handleChange}
+                    autoFocus
+                  />
+                  <span>{service.serviceName}</span>
+                </label>
+              ))}
+            </div>
           ))}
         </div>
       </div>
@@ -58,6 +66,7 @@ type IntakeServicesInputsProps = {
 type Service = {
   id: number;
   serviceName: string;
+  programName: string;
 };
 
 type ServicesRef = {

--- a/frontend/add-client/services.component.tsx
+++ b/frontend/add-client/services.component.tsx
@@ -99,7 +99,7 @@ export type CUService = {
   serviceName: string;
   serviceDescription: string;
   programId: string;
-  programDescription: string;
+  programName: string;
 };
 
 export type CUProgram = {

--- a/frontend/util/state-select.component.tsx
+++ b/frontend/util/state-select.component.tsx
@@ -77,4 +77,4 @@ export const stateNameToAbbreviation = {
 
 const statesArray = toPairs(stateNameToAbbreviation)
   .map(val => ({ key: val[1], label: val[0] }))
-  .sort((first, second) => first.label > second.label);
+  .sort((first, second) => (first.label > second.label ? 1 : 0));

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@reach/router": "^1.2.1",
     "@types/jest": "^24.0.15",
     "@types/jquery": "^3.3.30",
+    "@types/lodash-es": "^4.17.3",
     "@types/reach__router": "^1.2.4",
     "@types/react": "^16.8.23",
     "@types/react-dom": "16.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,6 +1000,18 @@
   dependencies:
     "@types/sizzle" "*"
 
+"@types/lodash-es@^4.17.3":
+  version "4.17.3"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.3.tgz#87eb0b3673b076b8ee655f1890260a136af09a2d"
+  integrity sha512-iHI0i7ZAL1qepz1Y7f3EKg/zUMDwDfTzitx+AlHhJJvXwenP682ZyGbgPSc5Ej3eEAKVbNWKFuwOadCj5vBbYQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.136"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.136.tgz#413e85089046b865d960c9ff1d400e04c31ab60f"
+  integrity sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
Now that we have the services grouped into programs, we can show them grouped by program in the Add/Edit client flow.

![intake-services-group](https://user-images.githubusercontent.com/5524384/62481897-f5d35a00-b770-11e9-9e38-0ecc416a30f0.gif)
