### PR TITLE
Removing Edit buttons from confirm add client page.

### DIFF
--- a/frontend/view-edit-client/client-home/view-edit-contact-info.component.tsx
+++ b/frontend/view-edit-client/client-home/view-edit-contact-info.component.tsx
@@ -132,12 +132,14 @@ export default function ViewEditContactInfo(props: ViewEditContactInfoProps) {
               </tr>
             </tbody>
           </table>
-          <button
-            className="secondary edit-button"
-            onClick={() => setIsEditing(true)}
-          >
-            Edit
-          </button>
+          {props.editable && (
+            <button
+              className="secondary edit-button"
+              onClick={() => setIsEditing(true)}
+            >
+              Edit
+            </button>
+          )}
         </>
       )}
     </ClientSection>

--- a/frontend/view-edit-client/client-home/view-edit-demographics-info.component.tsx
+++ b/frontend/view-edit-client/client-home/view-edit-demographics-info.component.tsx
@@ -203,12 +203,14 @@ export default function ViewEditDemographicsInfo(
               )}
             </tbody>
           </table>
-          <button
-            className="secondary edit-button"
-            onClick={() => setEditing(true)}
-          >
-            Edit
-          </button>
+          {props.editable && (
+            <button
+              className="secondary edit-button"
+              onClick={() => setEditing(true)}
+            >
+              Edit
+            </button>
+          )}
         </>
       )}
     </ClientSection>

--- a/frontend/view-edit-client/client-home/view-edit-intake-info.component.tsx
+++ b/frontend/view-edit-client/client-home/view-edit-intake-info.component.tsx
@@ -132,12 +132,14 @@ export default function ViewEditIntakeInfo(props: ViewEditIntakeInfoProps) {
               </tr>
             </tbody>
           </table>
-          <button
-            className="secondary edit-button"
-            onClick={() => setEditing(true)}
-          >
-            Edit
-          </button>
+          {props.editable && (
+            <button
+              className="secondary edit-button"
+              onClick={() => setEditing(true)}
+            >
+              Edit
+            </button>
+          )}
         </>
       )}
     </ClientSection>
@@ -219,4 +221,5 @@ type ViewEditIntakeInfoProps = {
   client: SingleClient;
   clientUpdated?(client: SingleClient): void;
   auditSummary?: AuditSummary;
+  editable?: boolean;
 };


### PR DESCRIPTION
Notice how I forgot to remove the Edit buttons from Contact Information on the confirm add client page. This fixes that.

<img width="847" alt="image" src="https://user-images.githubusercontent.com/5524384/64085758-d12bbd00-ccf1-11e9-8017-eea5db714afd.png">
