### PR TITLE
Resetting page to 1 whenever the sort changes.

### DIFF
--- a/frontend/client-list/client-list.component.tsx
+++ b/frontend/client-list/client-list.component.tsx
@@ -106,7 +106,8 @@ function reduceApiState(state: ApiState, action: ApiStateAction) {
         ...state,
         status: ApiStateStatus.shouldFetch,
         sortField: action.sortField,
-        sortOrder: action.sortOrder
+        sortOrder: action.sortOrder,
+        page: 1
       };
     default:
       throw Error();


### PR DESCRIPTION
When switching between ascending/descending sort in the client list, or switching to a whole new column to sort on, it makes more sense to take you back to page 1 rather than keep you on page 2 or greater of the newly sorted data.

See #256 