### PR TITLE
events api docs part 1 - start and get one

### DIFF
--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -22,8 +22,8 @@ GET /api/event/:id
   "eventLocation": "Saint Marks",
   "programId": {
     "id": 7,
-    "programName": "Preventative Health",
-    "programDescription": "Preventative Health"
+    "programName": "Preventive Health",
+    "programDescription": "Preventive Health"
   },
   "totalAttendence": 150,
   "isDeleted": false

--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -20,7 +20,7 @@ GET /api/event/:id
   "eventName": "Heath Fair",
   "eventDate": "2019-09-16",
   "eventLocation": "Saint Marks",
-  "relatedProgram": {
+  "programId": {
     "id": 7,
     "programName": "Preventative Health",
     "programDescription": "Preventative Health"

--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -32,7 +32,7 @@ GET /api/event/:id
 
 **_Note_**
 
-- `relatedProgram` is an array of integers program ids. See (/api-docs/list-services.md).
+- `programId` is an array of integers program ids. See (/api-docs/list-services.md).
 
 #### Not Found
 

--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -20,11 +20,6 @@ GET /api/event/:id
   "eventName": "Heath Fair",
   "eventDate": "2019-09-16",
   "eventLocation": "Saint Marks",
-  "programId": {
-    "id": 7,
-    "programName": "Preventive Health",
-    "programDescription": "Preventive Health"
-  },
   "totalAttendence": 150,
   "isDeleted": false
 }
@@ -61,11 +56,6 @@ GET /api/events
     "eventName": "Heath Fair",
     "eventDate": "2019-09-16",
     "eventLocation": "Saint Marks",
-    "programId": {
-      "id": 7,
-      "programName": "Preventive Health",
-      "programDescription": "Preventive Health"
-    },
     "totalAttendence": 150,
     "isDeleted": false
   },
@@ -96,7 +86,6 @@ POST /api/events
   "eventName": "Job Fair",
   "eventDate": "2019-09-24",
   "eventLocation": "Salt Lake City Library",
-  "programId": 9,
   "totalAttendence": 150
 }
 ```
@@ -112,7 +101,6 @@ PATCH /api/events/:id
   "eventName": "Job Fair",
   "eventDate": "2019-09-24",
   "eventLocation": "Salt Lake City Library",
-  "programId": 9,
   "totalAttendence": 150
 }
 ```

--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -43,3 +43,111 @@ If there is no lead with the provided id, you will get a 404 HTTP response, with
   "errors": ["Could not find event with id 2"]
 }
 ```
+
+## Get all Events
+
+### Request
+
+```http
+GET /api/events
+```
+
+### Response
+
+```json
+[
+  {
+    "id": 1,
+    "eventName": "Heath Fair",
+    "eventDate": "2019-09-16",
+    "eventLocation": "Saint Marks",
+    "programId": {
+      "id": 7,
+      "programName": "Preventive Health",
+      "programDescription": "Preventive Health"
+    },
+    "totalAttendence": 150,
+    "isDeleted": false
+  },
+  {
+    "id": 2,
+    "eventName": "Job Fair",
+    "eventDate": "2019-09-24",
+    "eventLocation": "Salt Lake City Library",
+    "programId": {
+      "id": 9,
+      "programName": "Workers' Rights",
+      "programDescription": "Workers' Rights"
+    },
+    "totalAttendence": 150,
+    "isDeleted": false
+  }
+]
+```
+
+## Create Event
+
+```http
+POST /api/events
+```
+
+```json
+{
+  "eventName": "Job Fair",
+  "eventDate": "2019-09-24",
+  "eventLocation": "Salt Lake City Library",
+  "programId": 9,
+  "totalAttendence": 150
+}
+```
+
+## Modify an Event
+
+```http
+PATCH /api/events/:id
+```
+
+```json
+{
+  "eventName": "Job Fair",
+  "eventDate": "2019-09-24",
+  "eventLocation": "Salt Lake City Library",
+  "programId": 9,
+  "totalAttendence": 150
+}
+```
+
+**_Notes_**
+
+- You can omit properties that you do not want to update.
+- The "isDeleted" property cannot be modified.
+
+### Response
+
+#### Success
+
+The response object will be the same as if you do a `GET /api/events/:id`
+
+#### Validation Error
+
+Validation errors will respond with HTTP status 400.
+
+```json
+{
+  "errors": ["You must provide a firstName"]
+}
+```
+
+## Delete a single Lead
+
+### Request
+
+```http
+DELETE /api/events/:id
+```
+
+### Response
+
+An HTTP 204 status is returned if the deletion was successful.
+
+An HTTP 400 status is returned if you cannot delete this event.

--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -64,11 +64,6 @@ GET /api/events
     "eventName": "Job Fair",
     "eventDate": "2019-09-24",
     "eventLocation": "Salt Lake City Library",
-    "programId": {
-      "id": 9,
-      "programName": "Workers' Rights",
-      "programDescription": "Workers' Rights"
-    },
     "totalAttendence": 150,
     "isDeleted": false
   }

--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -1,0 +1,45 @@
+# Events
+
+The list of events will document CU events.
+
+## Get single Event
+
+### Request
+
+```http
+GET /api/event/:id
+```
+
+### Response
+
+#### Success
+
+```json
+{
+  "id": 1,
+  "eventName": "Heath Fair",
+  "eventDate": "2019-09-16",
+  "eventLocation": "Saint Marks",
+  "relatedProgram": {
+    "id": 7,
+    "programName": "Preventative Health",
+    "programDescription": "Preventative Health"
+  },
+  "totalAttendence": 150,
+  "isDeleted": false
+}
+```
+
+**_Note_**
+
+- `relatedProgram` is an array of integers program ids. See (/api-docs/list-services.md).
+
+#### Not Found
+
+If there is no lead with the provided id, you will get a 404 HTTP response, with the following error message:
+
+```json
+{
+  "errors": ["Could not find event with id 2"]
+}
+```


### PR DESCRIPTION
Since they wanted to be able to use event info with the leads I'm also putting together the events api-docs to scope that out. We won't need the full events management part on the front end as part of this phase, but it appears we'll need at least part of the backend and a minimal frontend to cover the needs for the leads phase.

This PR gets us started on it.