### PR TITLE
Leads API docs  part 1 - get one

### DIFF
--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -7,3 +7,85 @@ Here is the list of the valid log types:
 - `leadCreated`,
 - `leadUpdated`,
 - `leadDeleted`
+
+## Get a single Lead
+
+### Request
+
+```http
+GET /api/leads/:id
+```
+
+### Response
+
+```json
+{
+  "id": 1,
+  "dateOfSignup": "2019-09-17",
+  "leadStatus": "active",
+  "contactStage" {
+    "first": "2019-05-06T06:00:00.000Z",
+    "second": null,
+    "third": null
+  },
+  "eventSource": {
+    "eventId": 1,
+    "eventName": "Health Fair",
+    "eventDate": "2019-09-16",
+    "eventLocation": "Saint Marks",
+    "relatedProgram": {
+      "id": 7,
+      "programName": "Preventative Health",
+      "programDescription": "Preventative Health"
+    }
+  },
+  "firstName": "Joel",
+  "lastName": "Denning",
+  "fullName": "Joel Denning",
+  "phone": "5555555555",
+  "smsConsent": true,
+  "zip": "84115",
+  "age": 25,
+  "gender": "male",
+  "intakeServices": [
+    {
+      "id": 1,
+      "serviceName": "Citizenship",
+      "serviceDescription": "Gain United States citizenship"
+    }
+  ],
+  "isDeleted": false,
+  "createdBy": {
+    "userId": 1,
+    "firstName": "Joel",
+    "lastName": "Denning",
+    "fullName": "Joel Denning",
+    "timestamp": "2019-05-06T06:00:00.000Z"
+  },
+  "lastUpdatedBy": {
+    "userId": 1,
+    "firstName": "Joel",
+    "lastName": "Denning",
+    "fullName": "Joel Denning",
+    "timestamp": "2019-05-06T06:00:00.000Z"
+  }
+}
+```
+
+**_Notes_**
+
+- `leadStatus` is an enum with the possible values of `active`, `inactive`, and `converted to client`.
+- `eventSource` is an array of integer event ids
+- `gender` is an enum with possible values of `female`, `male`, `transgender`, `nonbinary`, `other`.
+- `intakeServices` is an array of integers service ids. See (/api-docs/list-services.md).
+- `contactStage.firstAttempt`, `contactStage.secondAttempt`, `contactStage.thirdAttempt`,`created.timestamp` and `lastUpdated.timestamp` are ISO timestamps. `contactStage.firstAttempt`, `contactStage.secondAttempt`, `contactStage.thirdAttempt` are nullable.
+
+### Not Found
+
+If there is no lead with the provided id, you will get a 404 HTTP response, with the following error message:
+
+```json
+{
+  "errors": ["Could not find lead with id 2"]
+}
+```

--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -2,12 +2,6 @@
 
 The leads will document potiental clients sourced from CU events.
 
-Here is the list of the valid log types:
-
-- `leadCreated`,
-- `leadUpdated`,
-- `leadDeleted`
-
 ## Get a single Lead
 
 ### Request
@@ -28,6 +22,7 @@ GET /api/leads/:id
     "second": null,
     "third": null
   },
+  "inactivityReason": null,
   "eventSource": {
     "eventId": 1,
     "eventName": "Health Fair",
@@ -74,7 +69,8 @@ GET /api/leads/:id
 
 **_Notes_**
 
-- `leadStatus` is an enum with the possible values of `active`, `inactive`, and `converted to client`.
+- `leadStatus` is an enum with the possible values of `active`, `inactive`, and `convertedToClient`.
+- `inactivityReason` is an enum with the possible values of `doNotCallRequest`, `threeAttemptsNoResponse`, `wrongNumber`, `noLongerInterested`, and `relocated`.
 - `eventSource` is an array of integer event ids
 - `gender` is an enum with possible values of `female`, `male`, `transgender`, `nonbinary`, `other`.
 - `intakeServices` is an array of integers service ids. See (/api-docs/list-services.md).

--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -31,7 +31,7 @@ GET /api/leads/:id
     "relatedProgram": {
       "id": 7,
       "programName": "Preventive Health",
-      "programDescription": "Preventative Health"
+      "programDescription": "Preventive Health"
     }
   },
   "firstName": "Joel",

--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -28,7 +28,7 @@ GET /api/leads/:id
     "eventName": "Health Fair",
     "eventDate": "2019-09-16",
     "eventLocation": "Saint Marks",
-    "relatedProgram": {
+    "programId": {
       "id": 7,
       "programName": "Preventive Health",
       "programDescription": "Preventive Health"

--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -23,7 +23,7 @@ GET /api/leads/:id
   "id": 1,
   "dateOfSignup": "2019-09-17",
   "leadStatus": "active",
-  "contactStage" {
+  "contactStage": {
     "first": "2019-05-06T06:00:00.000Z",
     "second": null,
     "third": null

--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -27,12 +27,7 @@ GET /api/leads/:id
     "eventId": 1,
     "eventName": "Health Fair",
     "eventDate": "2019-09-16",
-    "eventLocation": "Saint Marks",
-    "programId": {
-      "id": 7,
-      "programName": "Preventive Health",
-      "programDescription": "Preventive Health"
-    }
+    "eventLocation": "Saint Marks"
   },
   "firstName": "Joel",
   "lastName": "Denning",

--- a/api-docs/leads.md
+++ b/api-docs/leads.md
@@ -35,7 +35,7 @@ GET /api/leads/:id
     "eventLocation": "Saint Marks",
     "relatedProgram": {
       "id": 7,
-      "programName": "Preventative Health",
+      "programName": "Preventive Health",
       "programDescription": "Preventative Health"
     }
   },


### PR DESCRIPTION
Leads docs for phase 4. 

Per our conversation at the CU meeting age and gender were decided to be kept in as is since birth date will be picked up when converting to client replacing the age attribute and both age and gender are needed for event planning and reporting involving leads. 

Incorporated events as the source of the leads per the meeting conversation also.