### PR TITLE
Make it possible to run mysql on a different port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: mysql
     command: --default-authentication-plugin=mysql_native_password
     ports:
-      - 3306:3306
+      - ${RDS_PORT:-3306}:3306
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_PASSWORD: password


### PR DESCRIPTION
This might come in handy if you (like me) already run various db versions
on different ports.

Note that for this to work you need to put both RDS_PORT and DATABASE_URL
in your .env file, since db-migrate won't pick up the former in dev mode.