### PR TITLE
Fixing typo in oneOnOneLightTouch. Resolves #328.

### DIFF
--- a/frontend/view-edit-client/interactions/single-interaction-slat.component.tsx
+++ b/frontend/view-edit-client/interactions/single-interaction-slat.component.tsx
@@ -597,7 +597,7 @@ export const interactionTypes = {
   inPerson: "In Person",
   byPhone: "By Phone",
   workshopTalk: "Workshop / Talk",
-  oneOnOneLightTough: "One On One / Light Tough",
+  oneOnOneLightTouch: "One On One / Light Touch",
   consultation: "Consultation"
 };
 


### PR DESCRIPTION
See #328. I found the bug by downloading the elastic beanstalk logs. They showed the following:

```
[ 'Property interactionType must be one of the following: inPerson, byPhone, workshopTalk, oneOnOneLightTouch, consultation. Received \'oneOnOneLightTough\'' ]
POST /api/clients/112/interactions 400 165 - 0.829 ms
```

See [here](https://github.com/JustUtahCoders/comunidades-unidas-internal/blob/a14ebcc56675a76d7aff4a8926938ca3b8923b08/backend/apis/clients/client-interactions/create-client-interaction.api.js#L25) for why the 400 is occurring (just a typo in the request)