### PR TITLE
Fix country of origin report when country is missing. Resolves #570.

### DIFF
--- a/backend/apis/reports/country-of-origin-report.api.js
+++ b/backend/apis/reports/country-of-origin-report.api.js
@@ -14,9 +14,9 @@ app.get(`/api/reports/countries-of-origin`, (req, res) => {
       SELECT COUNT(*) total, demographics.countryOfOrigin
       FROM
         (
-          SELECT MAX(dateAdded) latestDateAdded, clientId FROM demographics GROUP BY clientId
+          SELECT MAX(dateAdded) latestDateAdded, id FROM demographics GROUP BY clientId
         ) latestDems
-        JOIN demographics ON latestDems.latestDateAdded = demographics.dateAdded
+        JOIN demographics ON latestDems.id = demographics.id
         JOIN clients ON clients.id = demographics.clientId
       WHERE
         clients.isDeleted = false
@@ -36,7 +36,8 @@ app.get(`/api/reports/countries-of-origin`, (req, res) => {
 
     res.send({
       countriesOfOrigin: countriesOfOrigin.reduce((acc, row) => {
-        acc[row.countryOfOrigin] = row.total;
+        const countryName = row.countryOfOrigin || "Unknown";
+        acc[countryName] = row.total;
         return acc;
       }, {}),
       reportParameters: {},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.1"
 services:
   db:
     image: mysql
-    command: --default-authentication-plugin=mysql_native_password
+    command: --default-authentication-plugin=mysql_native_password --sql-mode=NO_ENGINE_SUBSTITUTION
     ports:
       - ${RDS_PORT:-3306}:3306
     environment:


### PR DESCRIPTION
See #570 - this was caused by adding clients without a country of origin for the very first time yesterday as part of the Suite CRM migration.