### PR TITLE
Client Creation: fix cannot create "Unknown" student status

### DIFF
--- a/backend/apis/clients/add-client.api.js
+++ b/backend/apis/clients/add-client.api.js
@@ -95,7 +95,7 @@ app.post("/api/clients", (req, res, next) => {
       sometimesValidInteger("householdIncome"),
       sometimesValidInteger("householdSize"),
       nullableValidInteger("juvenileDependents"),
-      sometimesValidBoolean("isStudent"),
+      nullableValidBoolean("isStudent"),
       sometimesValidEnum("housingStatus", "renter", "homeowner", "other"),
       sometimesValidEnum(
         "clientSource",


### PR DESCRIPTION
# When trying to create a client if the student status is unknown it throws an error from the backend:

`[develop-backend] [ "Property isStudent must be provided. Got 'null'" ]`

This change fixes the issue.

## Database correctly stores null values:
<img width="566" alt="Screen Shot 2020-08-21 at 2 23 42 PM" src="https://user-images.githubusercontent.com/3059715/90933875-85b86600-e3bd-11ea-93cf-d5694cc96f80.png">

## UI correctly displays null values
<img width="824" alt="Screen Shot 2020-08-21 at 2 23 56 PM" src="https://user-images.githubusercontent.com/3059715/90933892-8f41ce00-e3bd-11ea-97bc-4d4e6098af06.png">

## Data returned from the API correctly returns null values
<img width="478" alt="Screen Shot 2020-08-21 at 2 24 08 PM" src="https://user-images.githubusercontent.com/3059715/90933898-910b9180-e3bd-11ea-8253-a879b332b093.png">
