### PR TITLE
Adding network response to some reported errors

### DIFF
--- a/frontend/growls/error-listener.tsx
+++ b/frontend/growls/error-listener.tsx
@@ -1,5 +1,6 @@
 import { showGrowl, GrowlType } from "./growls.component";
 import { navigate } from "@reach/router";
+import { FetchError } from "../util/easy-fetch";
 
 window.addEventListener("error", function (evt: ErrorEvent) {
   showGrowl({
@@ -10,7 +11,7 @@ window.addEventListener("error", function (evt: ErrorEvent) {
   });
 
   function reportIssue() {
-    prepopulateError({
+    const errorInfo = {
       error:
         evt.error instanceof Error
           ? evt.error.message + "\n" + evt.error.stack
@@ -19,7 +20,17 @@ window.addEventListener("error", function (evt: ErrorEvent) {
       filename: evt.filename,
       lineno: evt.lineno,
       colno: evt.colno,
-    });
+      networkresponse: undefined,
+    };
+    if (evt.error instanceof FetchError && evt.error.body) {
+      // it's unlikely that this will ever throw an error but we want to ensure we don't break error reporting
+      try {
+        errorInfo.networkresponse = JSON.stringify(evt.error.body);
+      } catch (e) {
+        // do nothing
+      }
+    }
+    prepopulateError(errorInfo);
   }
 });
 

--- a/frontend/util/easy-fetch.ts
+++ b/frontend/util/easy-fetch.ts
@@ -45,11 +45,7 @@ export default function easyFetch(url: string, opts?: any) {
           throw err;
         })
         .catch((err) => {
-          const errorObject = new FetchError(
-            `Api request to '${url}' failed with HTTP status ${response.status}`
-          );
-          errorObject.status = response.status;
-          throw errorObject;
+          throw err;
         });
     }
   });
@@ -58,7 +54,7 @@ export default function easyFetch(url: string, opts?: any) {
 // @ts-ignore
 window.debugFetch = easyFetch;
 
-class FetchError extends Error {
+export class FetchError extends Error {
   body?: string;
   status?: number;
 }


### PR DESCRIPTION
# Adding network response to some Errors
I think it would've been much easier to fix the previous issue (fixed in #605) if we had seen the network response in the reported errors, as it wouldn't have relied on luck finding the exact issue after a report.

This MR makes a few changes so we can conditionally include the network response when we prepopulate errors for the "report error" feature

## Before This change
Here's what the populated message looked like before this change:
<img width="861" alt="Screen Shot 2020-08-21 at 3 34 02 PM" src="https://user-images.githubusercontent.com/3059715/90940483-2b72d180-e3cc-11ea-9d56-ca887388c8ca.png">

## After this change

<img width="821" alt="Screen Shot 2020-08-21 at 4 22 22 PM" src="https://user-images.githubusercontent.com/3059715/90940511-48a7a000-e3cc-11ea-93f1-c13617ac9aba.png">

### non `FetchError` example is unaffected

<img width="839" alt="Screen Shot 2020-08-21 at 4 23 33 PM" src="https://user-images.githubusercontent.com/3059715/90940535-5eb56080-e3cc-11ea-9485-f8e55900073a.png">
