### PR TITLE
Add date range on dateOfIntake for english-levels

### DIFF
--- a/backend/apis/reports/english-level.api.js
+++ b/backend/apis/reports/english-level.api.js
@@ -18,7 +18,8 @@ app.get(`/api/reports/english-levels`, (req, res) => {
 
   const sql = mysql.format(
     `
-      SELECT COUNT(*) total, demographics.englishProficiency        FROM
+      SELECT COUNT(*) total, demographics.englishProficiency
+      FROM
         (
           SELECT MAX(dateAdded) latestDateAdded, clientId FROM demographics GROUP BY clientId
         ) latestDems
@@ -29,8 +30,8 @@ app.get(`/api/reports/english-levels`, (req, res) => {
           SELECT dateOfIntake, clientId FROM intakeData
         ) intake ON intake.clientId = clients.id
       WHERE
-       clients.isDeleted = false
-       AND (dateOfIntake BETWEEN ? AND ?)
+        clients.isDeleted = false
+        AND (dateOfIntake BETWEEN ? AND ?)
       GROUP BY demographics.englishProficiency
       ;
     `,

--- a/backend/apis/reports/english-level.api.js
+++ b/backend/apis/reports/english-level.api.js
@@ -27,8 +27,8 @@ app.get(`/api/reports/english-levels`, (req, res) => {
         JOIN clients ON clients.id = demographics.clientId
         JOIN
         (
-          SELECT dateOfIntake, clientId FROM intakeData
-        ) intake ON intake.clientId = clients.id
+          SELECT MAX(dateAdded) latestDateAdded, dateOfIntake, clientId FROM intakeData GROUP BY clientId
+        ) latestIntake ON latestIntake.clientId = clients.id
       WHERE
         clients.isDeleted = false
         AND (dateOfIntake BETWEEN ? AND ?)

--- a/backend/apis/reports/english-level.api.js
+++ b/backend/apis/reports/english-level.api.js
@@ -18,8 +18,7 @@ app.get(`/api/reports/english-levels`, (req, res) => {
 
   const sql = mysql.format(
     `
-        SELECT COUNT(*) total, demographics.englishProficiency
-        FROM
+      SELECT COUNT(*) total, demographics.englishProficiency        FROM
         (
           SELECT MAX(dateAdded) latestDateAdded, clientId FROM demographics GROUP BY clientId
         ) latestDems
@@ -29,11 +28,11 @@ app.get(`/api/reports/english-levels`, (req, res) => {
         (
           SELECT dateOfIntake, clientId FROM intakeData
         ) intake ON intake.clientId = clients.id
-        WHERE
-        clients.isDeleted = false
-        AND (dateOfIntake BETWEEN ? AND ?)
-        GROUP BY demographics.englishProficiency
-        ;
+      WHERE
+       clients.isDeleted = false
+       AND (dateOfIntake BETWEEN ? AND ?)
+      GROUP BY demographics.englishProficiency
+      ;
     `,
     [startDate, endDate]
   );

--- a/frontend/reports/english-levels/english-levels-params.component.tsx
+++ b/frontend/reports/english-levels/english-levels-params.component.tsx
@@ -1,15 +1,39 @@
 import React from "react";
+import { useQueryParamState } from "../../util/use-query-param-state.hook";
 import { Link } from "@reach/router";
 
 export default function EnglishLevelsParams(props) {
+  const [startDate, setStartDate] = useQueryParamState("start", "");
+  const [endDate, setEndDate] = useQueryParamState("end", "");
+
   return (
-    <div className="actions">
-      <Link
-        className="primary button"
-        to={`${window.location.pathname}/results${window.location.search}`}
-      >
-        Run report
-      </Link>
-    </div>
+    <>
+      <div className="report-input">
+        <label htmlFor="start-date">Start date:</label>
+        <input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(evt) => setStartDate(evt.target.value)}
+        />
+      </div>
+      <div className="report-input">
+        <label htmlFor="end-date">End date:</label>
+        <input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(evt) => setEndDate(evt.target.value)}
+        />
+      </div>
+      <div className="actions">
+        <Link
+          className="primary button"
+          to={`${window.location.pathname}/results${window.location.search}`}
+        >
+          Run report
+        </Link>
+      </div>
+    </>
   );
 }

--- a/frontend/reports/english-levels/english-levels-results.component.tsx
+++ b/frontend/reports/english-levels/english-levels-results.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useReportsApi } from "../shared/use-reports-api";
 import BasicTableReport from "../shared/basic-table-report.component";
+import dayjs from "dayjs";
 import { formatPercentage, capitalize } from "../shared/report.helpers";
 import { sum, values } from "lodash-es";
 
@@ -16,43 +17,80 @@ export default function EnglishLevelsResults(props) {
   const totalClients = sum(values(data.englishLevels));
 
   return (
-    <BasicTableReport
-      title="Self Reported Client English Levels"
-      headerRows={
-        <tr>
-          <th>English Level</th>
-          <th>Client count</th>
-          <th>Percentage</th>
-        </tr>
-      }
-      contentRows={
-        <>
-          {Object.keys(data.englishLevels)
-            .sort(englishLevelComparator)
-            .map((englishLevel) => (
-              <tr key={englishLevel}>
-                <th>{capitalize(englishLevel)}</th>
-                <td>{data.englishLevels[englishLevel].toLocaleString()}</td>
-                <td>
-                  {formatPercentage(
-                    data.englishLevels[englishLevel].toLocaleString(),
-                    totalClients
-                  )}
-                </td>
-              </tr>
-            ))}
-        </>
-      }
-      footerRows={
-        <>
+    <div>
+      <BasicTableReport
+        title="Client Date Of Intake Range"
+        headerRows={
           <tr>
-            <th>Total</th>
-            <td>{totalClients.toLocaleString()}</td>
-            <td>100%</td>
+            <th>Parameter</th>
+            <th>Value</th>
           </tr>
-        </>
-      }
-    />
+        }
+        contentRows={
+          <>
+            <tr>
+              <th>Start Date</th>
+              <td>
+                {data.reportParameters.start
+                  ? dayjs(data.reportParameters.start).format("MMM D, YYYY")
+                  : "\u2014"}
+              </td>
+            </tr>
+            <tr>
+              <th>End Date</th>
+              <td>
+                {data.reportParameters.end
+                  ? dayjs(data.reportParameters.end).format("MMM D, YYYY")
+                  : "\u2014"}
+              </td>
+            </tr>
+          </>
+        }
+        footerRows={
+          <tr>
+            <th>Total Clients</th>
+            <td>{totalClients.toLocaleString()}</td>
+          </tr>
+        }
+      />
+      <BasicTableReport
+        title="Self Reported Client English Levels"
+        headerRows={
+          <tr>
+            <th>English Level</th>
+            <th>Client count</th>
+            <th>Percentage</th>
+          </tr>
+        }
+        contentRows={
+          <>
+            {Object.keys(data.englishLevels)
+              .sort(englishLevelComparator)
+              .map((englishLevel) => (
+                <tr key={englishLevel}>
+                  <th>{capitalize(englishLevel)}</th>
+                  <td>{data.englishLevels[englishLevel].toLocaleString()}</td>
+                  <td>
+                    {formatPercentage(
+                      data.englishLevels[englishLevel].toLocaleString(),
+                      totalClients
+                    )}
+                  </td>
+                </tr>
+              ))}
+          </>
+        }
+        footerRows={
+          <>
+            <tr>
+              <th>Total</th>
+              <td>{totalClients.toLocaleString()}</td>
+              <td>100%</td>
+            </tr>
+          </>
+        }
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
Issue: https://github.com/JustUtahCoders/comunidades-unidas-internal/issues/582

Add start and end form fields for [english-levels](http://localhost:8080/reports/english-levels) that grabs rows between two dates (inclusive) based on `dateOfIntake`.