### PR TITLE
Add date range for dateOfIntake for countries-of-origin

### DIFF
--- a/backend/apis/reports/country-of-origin-report.api.js
+++ b/backend/apis/reports/country-of-origin-report.api.js
@@ -1,13 +1,20 @@
 const { app, invalidRequest, pool, databaseError } = require("../../server");
-const { checkValid } = require("../utils/validation-utils");
+const { checkValid, nullableValidDate } = require("../utils/validation-utils");
 const mysql = require("mysql");
 
 app.get(`/api/reports/countries-of-origin`, (req, res) => {
-  const validationErrors = checkValid(req.query);
+  const validationErrors = checkValid(
+    req.query,
+    nullableValidDate("start"),
+    nullableValidDate("end")
+  );
 
   if (validationErrors.length > 0) {
     return invalidRequest(res, validationErrors);
   }
+
+  const startDate = req.query.start || "2000-01-01T0";
+  const endDate = req.query.end || "3000-01-01T0";
 
   const sql = mysql.format(
     `
@@ -18,13 +25,18 @@ app.get(`/api/reports/countries-of-origin`, (req, res) => {
         ) latestDems
         JOIN demographics ON latestDems.id = demographics.id
         JOIN clients ON clients.id = demographics.clientId
+        JOIN
+        (
+          SELECT MAX(dateAdded) latestDateAdded, dateOfIntake, clientId FROM intakeData GROUP BY clientId
+        ) latestIntake ON latestIntake.clientId = clients.id
       WHERE
         clients.isDeleted = false
+        AND (dateOfIntake BETWEEN ? AND ?)
       GROUP BY demographics.countryOfOrigin
       ORDER BY total DESC
       ;
     `,
-    []
+    [startDate, endDate]
   );
 
   pool.query(sql, (err, result) => {
@@ -40,7 +52,10 @@ app.get(`/api/reports/countries-of-origin`, (req, res) => {
         acc[countryName] = row.total;
         return acc;
       }, {}),
-      reportParameters: {},
+      reportParameters: {
+        start: req.query.start || null,
+        end: req.query.end || null,
+      },
     });
   });
 });

--- a/frontend/reports/country-of-origin/country-of-origin-params.component.tsx
+++ b/frontend/reports/country-of-origin/country-of-origin-params.component.tsx
@@ -1,15 +1,39 @@
 import React from "react";
+import { useQueryParamState } from "../../util/use-query-param-state.hook";
 import { Link } from "@reach/router";
 
 export default function CountryOfOriginParams(props) {
+  const [startDate, setStartDate] = useQueryParamState("start", "");
+  const [endDate, setEndDate] = useQueryParamState("end", "");
+
   return (
-    <div className="actions">
-      <Link
-        className="primary button"
-        to={`${window.location.pathname}/results${window.location.search}`}
-      >
-        Run report
-      </Link>
-    </div>
+    <>
+      <div className="report-input">
+        <label htmlFor="start-date">Start date:</label>
+        <input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(evt) => setStartDate(evt.target.value)}
+        />
+      </div>
+      <div className="report-input">
+        <label htmlFor="end-date">End date:</label>
+        <input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(evt) => setEndDate(evt.target.value)}
+        />
+      </div>
+      <div className="actions">
+        <Link
+          className="primary button"
+          to={`${window.location.pathname}/results${window.location.search}`}
+        >
+          Run report
+        </Link>
+      </div>
+    </>
   );
 }

--- a/frontend/reports/country-of-origin/country-of-origin-results.component.tsx
+++ b/frontend/reports/country-of-origin/country-of-origin-results.component.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { useReportsApi } from "../shared/use-reports-api";
 import BasicTableReport from "../shared/basic-table-report.component";
+import dayjs from "dayjs";
 import { formatPercentage, capitalize } from "../shared/report.helpers";
 import { sum, values, entries } from "lodash-es";
 import { countryCodeToName } from "../../util/country-select.component";
-
+//
 export default function CountriesOfOriginResults(props) {
   const { isLoading, data, error } = useReportsApi(
     `/api/reports/countries-of-origin`
@@ -27,10 +28,26 @@ export default function CountriesOfOriginResults(props) {
   return (
     <>
       <BasicTableReport
-        title="Client Countries of Origin"
+        title="Client Countries of Origin from Date of Intake Range"
         headerRows={null}
         contentRows={
           <>
+            <tr>
+              <th>Start Date</th>
+              <td>
+                {data.reportParameters.start
+                  ? dayjs(data.reportParameters.start).format("MMM D, YYYY")
+                  : "\u2014"}
+              </td>
+            </tr>
+            <tr>
+              <th>End Date</th>
+              <td>
+                {data.reportParameters.end
+                  ? dayjs(data.reportParameters.end).format("MMM D, YYYY")
+                  : "\u2014"}
+              </td>
+            </tr>
             <tr>
               <td>Known</td>
               <td>{totalKnownOriginClients}</td>

--- a/frontend/reports/country-of-origin/country-of-origin-results.component.tsx
+++ b/frontend/reports/country-of-origin/country-of-origin-results.component.tsx
@@ -5,7 +5,6 @@ import dayjs from "dayjs";
 import { formatPercentage, capitalize } from "../shared/report.helpers";
 import { sum, values, entries } from "lodash-es";
 import { countryCodeToName } from "../../util/country-select.component";
-//
 export default function CountriesOfOriginResults(props) {
   const { isLoading, data, error } = useReportsApi(
     `/api/reports/countries-of-origin`


### PR DESCRIPTION
Issue: https://github.com/JustUtahCoders/comunidades-unidas-internal/issues/582

Add start and end form fields for [countries-of-origin](http://localhost:8080/reports/countries-of-origin) that grabs rows between two dates (inclusive) based on `dateOfIntake`.