### PR TITLE
Add date range for ages-and-genders

### DIFF
--- a/frontend/reports/ages-and-genders/ages-and-genders-params.component.tsx
+++ b/frontend/reports/ages-and-genders/ages-and-genders-params.component.tsx
@@ -1,15 +1,39 @@
 import React from "react";
+import { useQueryParamState } from "../../util/use-query-param-state.hook";
 import { Link } from "@reach/router";
 
 export default function AgesAndGendersParams(props) {
+  const [startDate, setStartDate] = useQueryParamState("start", "");
+  const [endDate, setEndDate] = useQueryParamState("end", "");
+
   return (
-    <div className="actions">
-      <Link
-        className="primary button"
-        to={`${window.location.pathname}/results${window.location.search}`}
-      >
-        Run report
-      </Link>
-    </div>
+    <>
+      <div className="report-input">
+        <label htmlFor="start-date">Start date:</label>
+        <input
+          id="start-date"
+          type="date"
+          value={startDate}
+          onChange={(evt) => setStartDate(evt.target.value)}
+        />
+      </div>
+      <div className="report-input">
+        <label htmlFor="end-date">End date:</label>
+        <input
+          id="end-date"
+          type="date"
+          value={endDate}
+          onChange={(evt) => setEndDate(evt.target.value)}
+        />
+      </div>
+      <div className="actions">
+        <Link
+          className="primary button"
+          to={`${window.location.pathname}/results${window.location.search}`}
+        >
+          Run report
+        </Link>
+      </div>
+    </>
   );
 }

--- a/frontend/reports/ages-and-genders/ages-and-genders-results.components.tsx
+++ b/frontend/reports/ages-and-genders/ages-and-genders-results.components.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useReportsApi } from "../shared/use-reports-api";
 import BasicTableReport from "../shared/basic-table-report.component";
+import dayjs from "dayjs";
 import { uniq } from "lodash-es";
 import { capitalize } from "../shared/report.helpers";
 import CollapsibleTableRows, {
@@ -29,118 +30,161 @@ export default function AgesAndGendersResults(props) {
   ];
 
   return (
-    <BasicTableReport
-      title="Ages and Genders"
-      headerRows={
-        <tr>
-          <th>Client/Lead</th>
-          <th style={{ width: "15%" }}>Gender</th>
-          <th>Total</th>
-          {ageGroups.map((ageGroup) => (
-            <th key={ageGroup}>{ageGroup}</th>
-          ))}
-        </tr>
-      }
-      contentRows={
-        <>
-          <CollapsibleTableRows
-            everpresentRow={
-              <tr>
-                <th>Client</th>
-                <th>
-                  <ToggleCollapseButton />
-                </th>
-                <td>{data.totals.numClients.toLocaleString()}</td>
-                {ageGroups.map((ageGroup) => (
-                  <td key={ageGroup}>
-                    {data.clients.allGenders[ageGroup].toLocaleString()}
-                  </td>
-                ))}
-              </tr>
-            }
-            collapsibleRows={uniqueGenders.map((gender) => (
-              <tr key={gender}>
-                <th>{"\u2014"}</th>
-                <th>{capitalize(gender)}</th>
-                <td>{data.clients.allAges[gender].toLocaleString()}</td>
-                {ageGroups.map((ageGroup) => (
-                  <td key={ageGroup}>
-                    {data.clients[ageGroup][gender].toLocaleString()}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          />
-          <CollapsibleTableRows
-            everpresentRow={
-              <tr>
-                <th>Lead</th>
-                <th>
-                  <ToggleCollapseButton />
-                </th>
-                <td>{data.totals.numLeads.toLocaleString()}</td>
-                {ageGroups.map((ageGroup) => (
-                  <td key={ageGroup}>
-                    {data.leads.allGenders[ageGroup].toLocaleString()}
-                  </td>
-                ))}
-              </tr>
-            }
-            collapsibleRows={uniqueGenders.map((gender) => (
-              <tr>
-                <th>{"\u2014"}</th>
-                <th>{capitalize(gender)}</th>
-                <td>{data.leads.allAges[gender].toLocaleString()}</td>
-                {ageGroups.map((ageGroup) => (
-                  <td key={ageGroup}>
-                    {data.leads[ageGroup][gender].toLocaleString()}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          />
-        </>
-      }
-      footerRows={
-        <CollapsibleTableRows
-          everpresentRow={
+    <>
+      <BasicTableReport
+        title="Client Date Of Intake Range and Lead Date Of Sign Up Range"
+        headerRows={
+          <tr>
+            <th>Parameter</th>
+            <th>Value</th>
+          </tr>
+        }
+        contentRows={
+          <>
             <tr>
-              <th>All</th>
-              <th>
-                <ToggleCollapseButton />
-              </th>
+              <th>Start Date</th>
               <td>
-                {(
-                  data.totals.numLeads + data.totals.numClients
-                ).toLocaleString()}
+                {data.reportParameters.start
+                  ? dayjs(data.reportParameters.start).format("MMM D, YYYY")
+                  : "\u2014"}
               </td>
-              {ageGroups.map((ageGroup) => (
-                <td key={ageGroup}>
-                  {data.totals.ages[ageGroup].toLocaleString()}
-                </td>
-              ))}
             </tr>
-          }
-          collapsibleRows={uniqueGenders.map((gender) => (
             <tr>
-              <th>{"\u2014"}</th>
-              <th>{capitalize(gender)}</th>
-              <td>{data.totals.genders[gender].toLocaleString()}</td>
-              {ageGroups.map((ageGroup) => (
-                <td key={ageGroup}>
+              <th>End Date</th>
+              <td>
+                {data.reportParameters.end
+                  ? dayjs(data.reportParameters.end).format("MMM D, YYYY")
+                  : "\u2014"}
+              </td>
+            </tr>
+          </>
+        }
+        footerRows={
+          <>
+            <tr>
+              <th>Total Clients</th>
+              <td>{data.totals.numClients}</td>
+            </tr>
+            <tr>
+              <th>Total Leads</th>
+              <td>{data.totals.numLeads}</td>
+            </tr>
+          </>
+        }
+      />
+      <BasicTableReport
+        title="Ages and Genders"
+        headerRows={
+          <tr>
+            <th>Client/Lead</th>
+            <th style={{ width: "15%" }}>Gender</th>
+            <th>Total</th>
+            {ageGroups.map((ageGroup) => (
+              <th key={ageGroup}>{ageGroup}</th>
+            ))}
+          </tr>
+        }
+        contentRows={
+          <>
+            <CollapsibleTableRows
+              everpresentRow={
+                <tr>
+                  <th>Client</th>
+                  <th>
+                    <ToggleCollapseButton />
+                  </th>
+                  <td>{data.totals.numClients.toLocaleString()}</td>
+                  {ageGroups.map((ageGroup) => (
+                    <td key={ageGroup}>
+                      {data.clients.allGenders[ageGroup].toLocaleString()}
+                    </td>
+                  ))}
+                </tr>
+              }
+              collapsibleRows={uniqueGenders.map((gender) => (
+                <tr key={gender}>
+                  <th>{"\u2014"}</th>
+                  <th>{capitalize(gender)}</th>
+                  <td>{data.clients.allAges[gender].toLocaleString()}</td>
+                  {ageGroups.map((ageGroup) => (
+                    <td key={ageGroup}>
+                      {data.clients[ageGroup][gender].toLocaleString()}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            />
+            <CollapsibleTableRows
+              everpresentRow={
+                <tr>
+                  <th>Lead</th>
+                  <th>
+                    <ToggleCollapseButton />
+                  </th>
+                  <td>{data.totals.numLeads.toLocaleString()}</td>
+                  {ageGroups.map((ageGroup) => (
+                    <td key={ageGroup}>
+                      {data.leads.allGenders[ageGroup].toLocaleString()}
+                    </td>
+                  ))}
+                </tr>
+              }
+              collapsibleRows={uniqueGenders.map((gender) => (
+                <tr key={gender}>
+                  <th>{"\u2014"}</th>
+                  <th>{capitalize(gender)}</th>
+                  <td>{data.leads.allAges[gender].toLocaleString()}</td>
+                  {ageGroups.map((ageGroup) => (
+                    <td key={ageGroup}>
+                      {data.leads[ageGroup][gender].toLocaleString()}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            />
+          </>
+        }
+        footerRows={
+          <CollapsibleTableRows
+            everpresentRow={
+              <tr>
+                <th>All</th>
+                <th>
+                  <ToggleCollapseButton />
+                </th>
+                <td>
                   {(
-                    data.clients[ageGroup][gender] +
-                    data.leads[ageGroup][gender]
+                    data.totals.numLeads + data.totals.numClients
                   ).toLocaleString()}
                 </td>
-              ))}
-            </tr>
-          ))}
-        />
-      }
-      notes={[
-        `The All category will report a double count for a person who started as a Lead and then later became a Client. (Inquire if you want to change this).`,
-      ]}
-    />
+                {ageGroups.map((ageGroup) => (
+                  <td key={ageGroup}>
+                    {data.totals.ages[ageGroup].toLocaleString()}
+                  </td>
+                ))}
+              </tr>
+            }
+            collapsibleRows={uniqueGenders.map((gender) => (
+              <tr>
+                <th>{"\u2014"}</th>
+                <th>{capitalize(gender)}</th>
+                <td>{data.totals.genders[gender].toLocaleString()}</td>
+                {ageGroups.map((ageGroup) => (
+                  <td key={ageGroup}>
+                    {(
+                      data.clients[ageGroup][gender] +
+                      data.leads[ageGroup][gender]
+                    ).toLocaleString()}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          />
+        }
+        notes={[
+          `The All category will report a double count for a person who started as a Lead and then later became a Client. (Inquire if you want to change this).`,
+        ]}
+      />
+    </>
   );
 }


### PR DESCRIPTION
Issue: https://github.com/JustUtahCoders/comunidades-unidas-internal/issues/582

Add start and end form fields for [ages-and-genders](http://localhost:8080/reports/ages-and-genders) that grabs rows between two dates (inclusive) based on `dateOfIntake` for Clients and `dateOfSignUp` for Leads.

@joeldenning I think it is important to note that the start and end dates mean different things for clients and leads. Let me know if you want me to change how it displays the explanation.
![image](https://user-images.githubusercontent.com/14225943/93475154-8a394700-f8b5-11ea-9c9a-30f38b2766f9.png)
