### PR TITLE
Issue 684

### DIFF
--- a/api-docs/events.md
+++ b/api-docs/events.md
@@ -47,7 +47,21 @@ GET /api/events/:id
     "lastName": "Denning",
     "fullName": "Joel Denning",
     "timestamp": "2019-05-06T06:00:00.000Z"
-  }
+  },
+  "leads": [
+    {
+      "leadId": 1,
+      "firstName": "Justin",
+      "lastName": "McMurdie",
+      "fullName": "Justin McMurdie"
+    },
+    {
+      "leadId": 2,
+      "firstName": "Obi-Wan",
+      "lastName": "Kenobi",
+      "fullName": "Obi-Wan Kenobi"
+    }
+  ]
 }
 ```
 

--- a/backend/apis/events/get-event.api.js
+++ b/backend/apis/events/get-event.api.js
@@ -96,14 +96,12 @@ function getEventById(eventId, cbk, connection) {
 
     const leads = eventLeads.map((lead) => {
       return {
+        leadId: lead.leadId,
         firstName: lead.firstName,
         lastName: lead.lastName,
         fullName: responseFullName(lead.firstName, lead.lastName),
-        id: lead.leadId,
       };
     });
-
-    console.log("leads", leads);
 
     const clientGenders = _.groupBy(eventClients, "gender");
     const clientGenderCounts = Object.keys(clientGenders).reduce(

--- a/backend/apis/events/get-event.api.js
+++ b/backend/apis/events/get-event.api.js
@@ -62,7 +62,7 @@ function getEventById(eventId, cbk, connection) {
       WHERE events.id = ? AND isDeleted = false;
 
       SELECT
-        leadEvents.leadId, leads.gender, leads.leadStatus
+        leadEvents.leadId, leads.gender, leads.leadStatus, leads.firstName, leads.lastName
       FROM leadEvents JOIN leads ON leads.id = leadEvents.leadId
       WHERE leadEvents.eventId = ? AND leads.isDeleted = false;
     `,
@@ -93,6 +93,17 @@ function getEventById(eventId, cbk, connection) {
       },
       {}
     );
+
+    const leads = eventLeads.map((lead) => {
+      return {
+        firstName: lead.firstName,
+        lastName: lead.lastName,
+        fullName: responseFullName(lead.firstName, lead.lastName),
+        id: lead.leadId,
+      };
+    });
+
+    console.log("leads", leads);
 
     const clientGenders = _.groupBy(eventClients, "gender");
     const clientGenderCounts = Object.keys(clientGenders).reduce(
@@ -128,6 +139,7 @@ function getEventById(eventId, cbk, connection) {
         fullName: responseFullName(e.modifiedByFirstName, e.modifiedByLastName),
         timestamp: e.dateModified,
       },
+      leads,
     };
 
     cbk(err, event);

--- a/frontend/view-edit-events/event-home/event-home.component.tsx
+++ b/frontend/view-edit-events/event-home/event-home.component.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { SingleEvent } from "../view-event.component";
 import ViewEditEventInfo from "./view-edit-event-info.component";
 import ViewEventStats from "./view-event-stats.component";
+import ViewEventLeads from "./view-event-leads.component";
 
 export default function EventHome(props: EventHomeProps) {
   const { event, setEvent } = props;
@@ -14,6 +15,7 @@ export default function EventHome(props: EventHomeProps) {
     <div style={{ marginBottom: "3.2rem" }}>
       <ViewEditEventInfo event={event} eventUpdated={setEvent} />
       <ViewEventStats event={event} />
+      <ViewEventLeads event={event} />
     </div>
   );
 }

--- a/frontend/view-edit-events/event-home/view-event-leads.component.tsx
+++ b/frontend/view-edit-events/event-home/view-event-leads.component.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { SingleEvent } from "../view-event.component";
+import EventSection from "./event-section.component";
+import BasicTableReport from "../../reports/shared/basic-table-report.component";
+import { Link } from "@reach/router";
+
+export default function ViewEventStats(props: ViewEventStatsProps) {
+  const { leads } = props.event;
+
+  return (
+    <EventSection title="Leads">
+      <BasicTableReport
+        headerRows={
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+          </tr>
+        }
+        contentRows={
+          <>
+            {leads.map((lead) => (
+              <tr>
+                <td>
+                  <Link to={`/leads/${lead.id}`}>{lead.id}</Link>
+                </td>
+                <td>{lead.fullName}</td>
+              </tr>
+            ))}
+          </>
+        }
+      />
+    </EventSection>
+  );
+}
+
+type ViewEventStatsProps = {
+  event: SingleEvent;
+};

--- a/frontend/view-edit-events/event-home/view-event-leads.component.tsx
+++ b/frontend/view-edit-events/event-home/view-event-leads.component.tsx
@@ -21,7 +21,7 @@ export default function ViewEventStats(props: ViewEventStatsProps) {
             {leads.map((lead) => (
               <tr>
                 <td>
-                  <Link to={`/leads/${lead.id}`}>{lead.id}</Link>
+                  <Link to={`/leads/${lead.leadId}`}>{lead.leadId}</Link>
                 </td>
                 <td>{lead.fullName}</td>
               </tr>

--- a/frontend/view-edit-events/view-event.component.tsx
+++ b/frontend/view-edit-events/view-event.component.tsx
@@ -121,6 +121,7 @@ export type SingleEvent = {
   totalConvertedToClients?: number;
   leadGenders?: any;
   clientGenders?: any;
+  leads?: any;
 };
 
 type ViewEventProps = {


### PR DESCRIPTION
Fixes #684 

<img width="808" alt="Screen Shot 2020-11-13 at 4 07 18 PM" src="https://user-images.githubusercontent.com/3059715/99129274-52573300-25ca-11eb-9022-7bf2f717cf44.png">

Notes:
- I didn't implement it but it might be nice to also see which clients were created from the event by looking at this data as well: https://github.com/JustUtahCoders/comunidades-unidas-internal/blob/master/backend/apis/events/get-event.api.js#L83
- I debated restructuring the API response a bit more but went for the simplest possible change