### PR TITLE
Adding lead metadata to lead basic info card

### DIFF
--- a/frontend/view-edit-lead/lead-home/lead-metadata.component.tsx
+++ b/frontend/view-edit-lead/lead-home/lead-metadata.component.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import dayjs from "dayjs";
+
+export default function LeadMetadata(props) {
+  const { metadata } = props;
+  const { createdBy, lastUpdatedBy } = metadata;
+  return (
+    <div className="lead-metadata">
+      <div>
+        Created By: {`${createdBy.firstName} ${createdBy.lastName}`} -{" "}
+        {dayjs(createdBy.timestamp).format("YYYY-MM-DD")}
+      </div>
+      <div>
+        Last updated By:{" "}
+        {`${lastUpdatedBy.firstName} ${lastUpdatedBy.lastName}`} -{" "}
+        {dayjs(lastUpdatedBy.timestamp).format("YYYY-MM-DD h:mm A")}
+      </div>
+    </div>
+  );
+}

--- a/frontend/view-edit-lead/lead-home/lead-metadata.component.tsx
+++ b/frontend/view-edit-lead/lead-home/lead-metadata.component.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import dayjs from "dayjs";
 
-export default function LeadMetadata(props) {
-  const { metadata } = props;
-  const { createdBy, lastUpdatedBy } = metadata;
+export default function LeadMetadata(props: LeadMetadataProps) {
+  const { createdBy, lastUpdatedBy } = props;
   return (
     <div className="lead-metadata">
       <div>
@@ -18,3 +17,16 @@ export default function LeadMetadata(props) {
     </div>
   );
 }
+
+export type LeadMetadataProps = {
+  createdBy: {
+    firstName: string;
+    lastName: string;
+    timestamp: string;
+  };
+  lastUpdatedBy: {
+    firstName: string;
+    lastName: string;
+    timestamp: string;
+  };
+};

--- a/frontend/view-edit-lead/lead-home/lead-section.component.tsx
+++ b/frontend/view-edit-lead/lead-home/lead-section.component.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import { useCss } from "kremling";
+import LeadMetadata from "./lead-metadata.component";
 
 export default function LeadSection(props: LeadSectionProps) {
+  const { title, metadata, children } = props;
   const [expanded, setExpanded] = React.useState(() =>
-    localStorage.getItem(`cu-lead-section-expanded:${props.title}`)
-      ? JSON.parse(
-          localStorage.getItem(`cu-lead-section-expanded:${props.title}`)
-        )
+    localStorage.getItem(`cu-lead-section-expanded:${title}`)
+      ? JSON.parse(localStorage.getItem(`cu-lead-section-expanded:${title}`))
       : true
   );
 
@@ -14,7 +14,7 @@ export default function LeadSection(props: LeadSectionProps) {
 
   const toggleExpandAndStore = () => {
     localStorage.setItem(
-      `cu-lead-section-expanded:${props.title}`,
+      `cu-lead-section-expanded:${title}`,
       JSON.stringify(!expanded)
     );
     setExpanded(!expanded);
@@ -26,21 +26,40 @@ export default function LeadSection(props: LeadSectionProps) {
         className="unstyled lead-section-header"
         onClick={toggleExpandAndStore}
       >
-        <h1>{props.title}</h1>
+        <h1>{title}</h1>
+        {metadata && <LeadMetadata metadata={metadata} />}
       </button>
-      {expanded && <div className="lead-section-content">{props.children}</div>}
+      {expanded && <div className="lead-section-content">{children}</div>}
     </div>
   );
 }
 
 type LeadSectionProps = {
   title: string;
+  metadata?: {
+    createdBy: {
+      firstName: string;
+      lastName: string;
+      timestamp: string;
+    };
+    lastUpdatedBy: {
+      firstName: string;
+      lastName: string;
+      timestamp: string;
+    };
+  };
   children: JSX.Element | JSX.Element[];
 };
 
 const css = `
   & h1 {
     font-size: 2.1rem;
+  }
+
+  & .lead-metadata {
+    font-style: italic;
+    font-size: 1.2rem;
+    text-align: center;
   }
 
   & button.unstyled.lead-section-header {

--- a/frontend/view-edit-lead/lead-home/lead-section.component.tsx
+++ b/frontend/view-edit-lead/lead-home/lead-section.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useCss } from "kremling";
-import LeadMetadata from "./lead-metadata.component";
+import LeadMetadata, { LeadMetadataProps } from "./lead-metadata.component";
 
 export default function LeadSection(props: LeadSectionProps) {
   const { title, metadata, children } = props;
@@ -27,7 +27,7 @@ export default function LeadSection(props: LeadSectionProps) {
         onClick={toggleExpandAndStore}
       >
         <h1>{title}</h1>
-        {metadata && <LeadMetadata metadata={metadata} />}
+        {metadata && <LeadMetadata {...metadata} />}
       </button>
       {expanded && <div className="lead-section-content">{children}</div>}
     </div>
@@ -36,18 +36,7 @@ export default function LeadSection(props: LeadSectionProps) {
 
 type LeadSectionProps = {
   title: string;
-  metadata?: {
-    createdBy: {
-      firstName: string;
-      lastName: string;
-      timestamp: string;
-    };
-    lastUpdatedBy: {
-      firstName: string;
-      lastName: string;
-      timestamp: string;
-    };
-  };
+  metadata?: LeadMetadataProps;
   children: JSX.Element | JSX.Element[];
 };
 

--- a/frontend/view-edit-lead/lead-home/view-edit-basic-lead-info.component.tsx
+++ b/frontend/view-edit-lead/lead-home/view-edit-basic-lead-info.component.tsx
@@ -49,6 +49,10 @@ export default function ViewEditBasicLeadInfo(
       title={
         apiStatus.isEditing ? "Edit Basic Information" : "Basic information"
       }
+      metadata={{
+        createdBy: lead.createdBy,
+        lastUpdatedBy: lead.lastUpdatedBy,
+      }}
     >
       {apiStatus.isEditing ? (
         <BasicLeadInformationInputs


### PR DESCRIPTION
Fixes #694 

I chose to do it this way after examining other areas of the app. A contact has a similar header, it's slightly different but I tried to capture the look and feel with this change.

It didn't feel right in other areas and this area _felt_ the most visually consistent to me. If you want changes to the approach or location please let me know.

<img width="784" alt="Screen Shot 2020-11-20 at 4 12 39 PM" src="https://user-images.githubusercontent.com/3059715/99858653-44199180-2b4b-11eb-8398-ee8d81944fd4.png">

