### PR TITLE
UI for follow-ups in Interactions by Service report

### DIFF
--- a/backend/apis/reports/interactions-by-service.api.js
+++ b/backend/apis/reports/interactions-by-service.api.js
@@ -305,7 +305,7 @@ app.get(`/api/reports/interactions-by-service`, (req, res) => {
 
     const grandTotal = {
       numInteractions: _.sum(programTotals.map((p) => p.numInteractions)),
-      numFollowUps: _.sum(followUpProgramTotals.map((p) => p.numInteractions)),
+      numFollowUps: _.sum(followUpProgramTotals.map((p) => p.numFollowUps)),
       numClients: totalClients[0].numClients,
       totalInteractionSeconds: _.sum(
         programTotals.map((p) => p.totalInteractionSeconds)

--- a/backend/apis/reports/interactions-by-service.api.js
+++ b/backend/apis/reports/interactions-by-service.api.js
@@ -104,6 +104,23 @@ app.get(`/api/reports/interactions-by-service`, (req, res) => {
       ON services.id = clientHours.serviceId
       ;
 
+      -- unspecified follow ups (unassociated with a program) between selected dates
+      SELECT id, TIME_TO_SEC(duration) followUpSeconds
+      FROM followUps
+      WHERE dateOfContact >= ?
+        AND dateOfContact <= ?
+        AND id NOT IN
+          (SELECT followUpId 
+          FROM followUpServices)
+      ;
+
+      -- all follow ups, including those not associated with a program, between selected dates
+      SELECT COUNT(*) totalFollowUps, SUM(TIME_TO_SEC(duration)) totalFollowUpSeconds
+      FROM followUps
+      WHERE dateOfContact >= ?
+        AND dateOfContact <= ?
+      ;
+
       -- num of follow ups per service
       SELECT totalFollowUps, services.id serviceId, services.serviceName, programs.id programId, programs.programName
       FROM
@@ -161,6 +178,10 @@ app.get(`/api/reports/interactions-by-service`, (req, res) => {
       endDate,
       startDate,
       endDate,
+      startDate,
+      endDate,
+      startDate,
+      endDate,
     ]
   );
 
@@ -176,6 +197,8 @@ app.get(`/api/reports/interactions-by-service`, (req, res) => {
       serviceHours,
       totalClients,
       serviceHoursByFollowUps,
+      unspecifiedFollowUps,
+      allFollowUps,
       serviceFollowUps,
       programFollowUpClients,
       serviceFollowUpClients,
@@ -216,6 +239,16 @@ app.get(`/api/reports/interactions-by-service`, (req, res) => {
         totalFollowUpSeconds: 0,
         totalDuration: "00:00:00",
       })
+    );
+
+    const unspecifiedFollowUpTotals = {
+      numFollowUps: unspecifiedFollowUps.length,
+      totalSeconds: _.sum(
+        unspecifiedFollowUps.map((followUp) => followUp.followUpSeconds)
+      ),
+    };
+    unspecifiedFollowUpTotals.totalDuration = toDuration(
+      unspecifiedFollowUpTotals.totalSeconds
     );
 
     const serviceTotals = serviceInteractions.map((service) => ({
@@ -305,25 +338,21 @@ app.get(`/api/reports/interactions-by-service`, (req, res) => {
 
     const grandTotal = {
       numInteractions: _.sum(programTotals.map((p) => p.numInteractions)),
-      numFollowUps: _.sum(followUpProgramTotals.map((p) => p.numFollowUps)),
+      numFollowUps: allFollowUps[0].totalFollowUps,
       numClients: totalClients[0].numClients,
       totalInteractionSeconds: _.sum(
         programTotals.map((p) => p.totalInteractionSeconds)
       ),
-      totalFollowUpSeconds: _.sum(
-        followUpProgramTotals.map((p) => p.totalFollowUpSeconds)
-      ),
+      allFollowUpSeconds: allFollowUps[0].totalFollowUpSeconds,
+      allFollowUpDuration: toDuration(allFollowUps[0].totalFollowUpSeconds),
     };
     grandTotal.totalDuration = toDuration(grandTotal.totalInteractionSeconds);
-
-    grandTotal.totalFollowUpDuration = toDuration(
-      grandTotal.totalFollowUpSeconds
-    );
 
     res.send({
       grandTotal,
       programs: programTotals,
       followUpProgramTotals: followUpProgramTotals,
+      unspecifiedFollowUpTotals: unspecifiedFollowUpTotals,
       services: serviceTotals,
       followUpServicesTotal: followUpServicesTotal,
       reportParameters: {

--- a/frontend/reports/interactions-by-service/interactions-by-service-results.component.tsx
+++ b/frontend/reports/interactions-by-service/interactions-by-service-results.component.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { useReportsApi } from "../shared/use-reports-api";
 import BasicTableReport from "../shared/basic-table-report.component";
-import { formatPercentage, formatDuration } from "../shared/report.helpers";
+import { formatDuration } from "../shared/report.helpers";
 import CollapsibleTableRows, {
   ToggleCollapseButton,
   ToggleAllButton,
 } from "../shared/collapsible-table-rows.component";
 import dayjs from "dayjs";
-import { values } from "lodash-es";
+import { sumBy, values } from "lodash-es";
 
 export default function InteractionsByService(props) {
   const { isLoading, data, error } = useReportsApi(
@@ -74,6 +74,30 @@ export default function InteractionsByService(props) {
     );
   };
 
+  const renderUnspecifiedRow = () => {
+    return (
+      <CollapsibleTableRows
+        key="unspecified"
+        everpresentRow={
+          <tr>
+            <th>Unspecified</th>
+            <td />
+            <td />
+            <td />
+            <td />
+            <td>
+              {data.unspecifiedFollowUpTotals.numFollowUps.toLocaleString()}
+            </td>
+            <td>
+              {formatDuration(data.unspecifiedFollowUpTotals.totalDuration)}
+            </td>
+          </tr>
+        }
+        collapsibleRows={[]}
+      />
+    );
+  };
+
   return (
     <>
       <BasicTableReport
@@ -118,7 +142,10 @@ export default function InteractionsByService(props) {
             <th>Follow-up Hours</th>
           </tr>
         }
-        contentRows={data.programs.map(renderProgramRows)}
+        contentRows={[
+          ...data.programs.map(renderProgramRows),
+          renderUnspecifiedRow(),
+        ]}
         footerRows={
           <tr>
             <th>All programs</th>
@@ -129,7 +156,7 @@ export default function InteractionsByService(props) {
             <td>{data.grandTotal.numInteractions}</td>
             <td>{formatDuration(data.grandTotal.totalDuration)}</td>
             <td>{data.grandTotal.numFollowUps}</td>
-            <td>{formatDuration(data.grandTotal.totalFollowUpDuration)}</td>
+            <td>{formatDuration(data.grandTotal.allFollowUpDuration)}</td>
           </tr>
         }
       />


### PR DESCRIPTION
I noticed a couple of weird things while adding this UI.

1. Follow-ups aren't required to have an associated service. The follow-ups with unspecified services don't show up anywhere in this report or in the total. It seems misleading/confusing to me. Thoughts on adding an "unspecified" row? (this would also require a backend change, happy to do that)

2. If a follow-up is associated with multiple services, the "grand total" counts that same follow-up twice in the sums for count & duration. It seems like we want to change the backend reporting logic here -- I'm happy to do this, but because it's a nontrivial change I wanted to check if there is any reason we might want to keep this or maybe even change a follow-up to only be associated with 1 service.

For example:

Created a follow up for a client with two different services selected:
<img width="506" alt="Screen Shot 2020-12-22 at 6 25 17 PM" src="https://user-images.githubusercontent.com/2423414/102948777-ecd94a80-4483-11eb-8980-9ca1ec810879.png">

Report shows follow up count/duration correctly on individual line items, but the total counts the same follow-up twice:
<img width="1122" alt="Screen Shot 2020-12-22 at 6 25 54 PM" src="https://user-images.githubusercontent.com/2423414/102948780-ee0a7780-4483-11eb-9640-d7695f1aea68.png">
